### PR TITLE
Fix repo name for contributor workflow

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: BobAnkh/add-contributors@master
       with:
-        REPO_NAME: 'madebygps/self-taught-guide-to-cloud-computing'
+        REPO_NAME: 'learntocloud/learn-to-cloud'
         CONTRIBUTOR: '### Contributors'
         COLUMN_PER_ROW: '6'
         ACCESS_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
It was still using the old version and it was not running any longer (hasn't been updated in weeks)