### PR TITLE
Broken Link for Phase 2 Python certifications

### DIFF
--- a/fr/README.md
+++ b/fr/README.md
@@ -2,27 +2,27 @@
 
 **[version web ici](https://learntocloud.guide)**
 
-Ce guide est basé sur nos experiences en debutant dans le Cloud et DevOps. une fois fini,vous devriez avoir des connaissances techniques pour des rôles comme:
+Ce guide est basé sur nos experiences en debutant dans le Cloud et DevOps. Une fois fini, vous devriez avoir des connaissances techniques pour des rôles comme:
 
 - Administrateur systeme.
 - Ingenieur de support cloud.
 - Administrateur Cloud.
 
-Vous pouvez apprendre plus sur notre parcours dans le cloud ici :
-- [le parcours de Rishab  de service d’assistance à ingenieur DevOps sans diplome universitaire ](https://youtu.be/LZuWZ0SBYm8) 
-- [le parcours de Gwyneth de service d’assistance à ingenieur cloud  sans diplome universitaire](https://youtu.be/kluKaLXJ2lg)
-- Nous avons essayé de le garder aussi général et d’utiliser les options les plus populaires(en terme des contenus,communauté,et emplois) autant que possible. le programamme de 6 mois est quelque chose que nous mettons en place pour aider avec la plannification et Suivie. cela pourrait vous prendre plus ou moins de temps pour chaque phase et si c’est le cas,c’est tout à fait vrai.
+Vous pouvez apprendre plus sur notre parcours dans le cloud ici:
+- [Le parcours de Rishab  de service d’assistance à ingenieur DevOps sans diplome universitaire (En Anglais)](https://youtu.be/LZuWZ0SBYm8) 
+- [Le parcours de Gwyneth de service d’assistance à ingenieur cloud  sans diplome universitaire (En Anglais)](https://youtu.be/kluKaLXJ2lg)
+- Nous avons essayé de le garder aussi général et d’utiliser les options les plus populaires (en terme des contenus,communauté,et emplois) autant que possible. Le programamme de 6 mois est quelque chose que nous mettons en place pour aider avec la plannification et suivie. Cela pourrait vous prendre plus ou moins de temps pour chaque phase et si c’est le cas, c’est tout à fait vrai.
 
 
 | Ordre| Matière                 | Temps à Devouer |
 |-------|---------------------------------|-------------------|
 | [0](phase0/README.md)     | Commencez avec zéro experience en tech | optionel 
-| [1](phase1/README.md)     | Linux,Réseau,et les Fondamentaux du Scripting  | 4 semaines          |
+| [1](phase1/README.md)     | Linux, Réseau, et les Fondamentaux du Scripting  | 4 semaines          |
 | [2](phase2/README.md)     | Les fondamentaux de la programmation | 4 semaines         |
 | [3](phase3/README.md)    |Les fondamentaux des plateformes cloud | 8 semaines          |
-| [4](phase4/README.md)     | Les fondamentaux du Devops      | 8 semaines          |
+| [4](phase4/README.md)     | Les fondamentaux du DevOps      | 8 semaines          |
 
 
 
 
-### [Allez à phase 1: Linux,Réseau,et les Fondamentaux du Scripting](phase1/README.md)
+### [Allez à phase 1: Linux, Réseau, et les Fondamentaux du Scripting](phase1/README.md)

--- a/fr/README.md
+++ b/fr/README.md
@@ -1,6 +1,6 @@
 # Bienvenue 
 
-**[version web ici](https://learntocloud.guide)**
+**[Version web ici](https://learntocloud.guide)**
 
 Ce guide est basé sur nos experiences en debutant dans le Cloud et DevOps. Une fois fini, vous devriez avoir des connaissances techniques pour des rôles comme:
 

--- a/fr/phase1/README.md
+++ b/fr/phase1/README.md
@@ -2,11 +2,11 @@
 
 ## Comment s’applique cette phase au Cloud?
 
-le cloud est un tas des serveurs Linux mise en réseau ensemble. apprendre les bases des fonctionnement réseaux,et comment interagir avec ces serveurs via les commandes, et automatiser ces commandes via un script, est l’objet de cette phase. si vous êtes déjà un administrateur linux ou ingenieur réseau,vous pouvez appliquer vos connaissances dans le cloud.
+Le cloud est un tas de serveurs Linux mis en réseau ensemble. Apprendre les bases des fonctionnement réseaux, et comment interagir avec ces serveurs via les commandes, et automatiser ces commandes via un script, est l’objet de cette phase. Si vous êtes déjà un administrateur linux ou ingénieur réseau, vous pouvez appliquer vos connaissances dans le cloud.
 
 ## Comment décomposer cette phase
 
- Je suggérerais de passer du temps sur ces trois sujets et cette chronologie:
+ Je suggère de passer du temps sur ces trois sujets et dans cet order:
 
 | Ordre |   sujets                        | Temps à devouer | 
 |-------|---------------------------------|-------------------|
@@ -14,57 +14,57 @@ le cloud est un tas des serveurs Linux mise en réseau ensemble. apprendre les b
 | 2 | Introduction au Réseau  | 1 semaine         |
 | 3 | Introduction au Scripting bash | 1 semaine           |
 
-Bien sûr,n’hésitez pas à passer autant de temps que vous le souhaitez, les gens ont demandé un calendrier et une décomposition, alors je l’ai ajouté..
+Bien sûr, n’hésitez pas à passer autant de temps que vous le souhaitez, les gens ont demandé un calendrier et une décomposition, alors je l’ai ajouté..
 
 ## Resources
 
 |   Sujets   | Titre    |  Notes     |
 | :------------- | ---------- | :----------- |
-|  Linux | [Linux de base pour les pirates](https://nostarch.com/linuxbasicsforhackers)   |  Ce livre a rendu l’apprentissage de Linux amusant! C’est assez facile à suivre et à lire un chapitre jour après jour. Vous n’avez pas besoin de lire le tout,les 9 premiers chapitres couvrent la plupart de ce que vous devez savoir.  |
-| Linux   | [La ligne de commande linux ](https://nostarch.com/tlcl2) | Je l’ai utilisé davantage comme référence pour renforcer les sujets du premier livre.. |
-| Linux   | [Parcours Linux](https://linuxjourney.com/) | Une maniere interactive d’apprendre Linux et la ligne de commande !|
-| Reseau  | [Cours de réseautage informatique FreeCodeCamp](https://youtu.be/qiQR5rTSshw) | Ce cours complet de réseau informatique vous préparera à configurer,gérer et dépanner les réseaux informatiques.|
-| Introduction à Bash | [Cours de bash linux par GPS](https://youtu.be/qALScO3E61I) | Une introduction à Bash!|
-| Scripting Bash   | [Introduction au scripting bash](https://youtu.be/_n5ZegzieSQ) | Fantastique introduction au script bash, la voix de Joe Collins est apaisante!|
-| Les commandes Bash | [Cours intensif pour débutants sur Linux Bash](https://youtu.be/qALScO3E61I) | une vidéo d’une heure réalisée par Gwyneth
+|  Linux | [Bases de Linux pour les pirates (Anglais)](https://nostarch.com/linuxbasicsforhackers)   |  Ce livre a rendu l’apprentissage de Linux amusant! C’est assez facile à suivre et à lire un chapitre jour après jour. Vous n’avez pas besoin de lire tout, les 9 premiers chapitres couvrent la plupart de ce que vous devez savoir.  |
+| Linux   | [La ligne de commande linux (Anglais)](https://nostarch.com/tlcl2) | Je l’ai utilisé davantage comme référence pour renforcer les sujets du premier livre.. |
+| Linux   | [Parcours Linux (Anglais)](https://linuxjourney.com/) | Une manière interactive d’apprendre Linux et la ligne de commande !|
+| Reseau  | [Cours de réseautage informatique FreeCodeCamp (Anglais)](https://youtu.be/qiQR5rTSshw) | Ce cours complet de réseau informatique vous préparera à configurer, gérer et dépanner les réseaux informatiques.|
+| Introduction à Bash | [Cours de bash linux par GPS (Anglais)](https://youtu.be/qALScO3E61I) | Une introduction à Bash!|
+| Scripting Bash   | [Introduction au scripting bash (Anglais)](https://youtu.be/_n5ZegzieSQ) | Fantastique introduction au script bash, la voix de Joe Collins est apaisante!|
+| Les commandes Bash | [Cours intensif pour débutants sur Linux Bash (Anglais)](https://youtu.be/qALScO3E61I) | Une vidéo d’une heure réalisée par Gwyneth
 
 ## Projets
 
  Titre  | Resource     |
  :---------- | :----------- |
- Installez linux sur un ordinateur   | Cherchez une distribution et installez (Nous aimons [Pop!_OS](https://pop.system76.com/)) |
+ Installez linux sur un ordinateur   | Cherchez une distribution et installez la (Nous aimons [Pop!_OS](https://pop.system76.com/)) |
 Configurez un [Serveur Lamp](https://en.wikipedia.org/wiki/LAMP_(software_bundle)) | Une tâche d’administration Linux assez populaire. |
  Deployer un serveur NAS | Consultez [FreeNAS](https://www.freenas.org/) |
  Deployer votre propre Cloud | Consultez [NextCloud](https://nextcloud.com/) |
   Convertissez les fichiers Videos | Consultez [ffmpeg](https://ffmpeg.org/ffmpeg.html) utilisez-le pour écrire un script qui convertit un fichier .mov en mp4
 
-## Les choses que vous devez être familier avec à la fin de cette phase
+## Les choses avec lesquelles vous devez être familier avec à la fin de cette phase
 
 ### Commandes
 
-- Naviguez avec la commande `cd`
+- Naviguer avec la commande `cd`
 - Comment lister les contenus d’un repertoire en utilisant la commande `ls`
-- Creer,copier,deplacer,renommer, des repertoires et fichiers avec `mkdir`, `cp`, `rm`, et la commande `touch`.
+- Créer, copier, deplacer, renommer, des repertoires et fichiers avec `mkdir`, `cp`, `rm`, et la commande `touch`.
 - Trouver les choses avec `locate`, `whereis`, `which`, et la commande `find` 
 - Comprendre comment apprendre plus sur les commandes avec `which`, `man`, et la commande `--help`
-- Familier en trouvant les details des logs dans `/var/log`
+- Capable de trouver les details des logs dans `/var/log`
 - Comment afficher le contenu d’un fichier avec `cat`, `less`, `more`, `tail`, `head`.
 - Filtrer avec `grep` et `sed`.
 - Redirection des entrées standard, sorties et erreurs avec l'operateur `>`  et la commande `tee`
 - Comment utiliser les pipelines avec l'operateur `|` .
 - Manipuler les fichiers avec `nano` ou `vim`.
-- Installer et desinstaller les paquets. Depend de la distribution, utilisation basée sur Debian `apt`.
+- Installer et désinstaller les paquets. Selon la distribution, utilisation basée sur Debian `apt`.
 - Controle des permissions avec les commandes `chown`, `chgrp`, `chmod`.
 - Créer des utilisateurs et la commande `sudo`
 - Gestion des processus avec `ps`, `top`, `nice`, `kill`
-- Gérez l’environnement et les variables définies par l’utilisateur avec les commandes `env`, `set`, `export` 
-- Ajoutez vos repertoires à votre chemin `PATH`.
+- Gérer l’environnement et les variables définies par l’utilisateur avec les commandes `env`, `set`, `export` 
+- Ajouter vos repertoires à votre chemin `PATH`.
 - Compression et archivage avec `tar`, `gzip`, `gunzip`.
-- Comment accedez à un serveur linux avec `ssh`.
+- Comment acceder à un serveur linux avec `ssh`.
 
 ### Reseau
 
-Les concepts que vous devriez être familier.
+Les concepts qui devraient vous être familiers.
 
 - Le modèle OSI
 - L’addressage IP
@@ -78,15 +78,15 @@ Les concepts que vous devriez être familier.
 
 ### Scripting bash
 
-- qu’est-ce qu’un shell ?
-- qu’est-ce qu'un bash ?
-- Pourquoi un script doit commencer avec #!?
-- qu’est ce que les variables et comment les utiliser
+- Qu’est-ce qu’une Shell ?
+- Qu’est-ce que Bash ?
+- Pourquoi un script doit commencer avec `#!`?
+- Que sont les variables et comment les utiliser
 - Comment accepter les entrées utilisateurs 
 - Comment executer un script
 
 ## Les Certifications que vous pourriez vouloir voir
-il y a plusieurs certifications et vous pouvez choisir pour étudier pour l’un d’entre eux vraiment,mais beaucoup d’entre eux couvrent beaucoup plus que ce que vous devez savoir pour une base solide et sont plus axés sur l’administration Linux.
+Il y a plusieurs certifications et vous pouvez choisir d'étudier pour n'importe lesquelles, mais beaucoup d’entre elles couvrent beaucoup plus que ce que vous devez savoir pour une base solide et sont plus axés sur l’administration Linux.
 
 - [LPI essentials](https://www.lpi.org/our-certifications/linux-essentials-overview)
 - [RedHat](https://www.redhat.com/en/services/training-and-certification)
@@ -95,7 +95,7 @@ il y a plusieurs certifications et vous pouvez choisir pour étudier pour l’un
 - [LPI](https://www.lpi.org/)
 - [Comptia Linux+](https://www.comptia.org/certifications/linux)
 
-Il existe également des tonnes de certifications réseau, et similaires à celles de Linux, elles sont plus axées sur le fait de vous donner beaucoup de connaissances afin que vous puissiez devenir un ingénieur / spécialiste des réseaux, encore une fois à un niveau d’introduction, c’est un peu exagéré. Si vous vouliez en obtenir un, jetez un coup d’œil aux [Cisco certifications](https://www.cisco.com/c/en/us/training-events/training-certifications/certifications.html) qui sont à peu près la norme de l’industrie et/ou [Comptia Network+](https://www.comptia.org/certifications/network).
+Il existe également des tonnes de certifications réseau, et de même que celles de Linux, elles sont plus axées a vous donner beaucoup de connaissances afin que vous puissiez devenir un ingénieur / spécialiste des réseaux, encore une fois à un niveau d’introduction, c’est un peu exagéré. Si vous voulez en obtenir une, jetez un coup d’œil aux [Cisco certifications](https://www.cisco.com/c/en/us/training-events/training-certifications/certifications.html) qui sont à peu près la norme de l’industrie et/ou [Comptia Network+](https://www.comptia.org/certifications/network).
 
 À la fin de la journée, si vous voulez les prendre, allez-y :)
   

--- a/fr/phase2/README.md
+++ b/fr/phase2/README.md
@@ -2,14 +2,14 @@
 
 ## Comment s'applique cette phase au cloud ?
 
-Vous utiliserez du code pour automatiser les tâches et déployer l’infrastructure. Vous n’avez pas besoin de savoir comment créer des applications complètes, mais comprendre les bases de la programmation vous donnera un avantage. Il existe des rôles des développeurs dédiés dans le cloud.Pour ceux dont vous aurez besoin de savoir comment construire des solutions complètes, Consultez [cette video](https://youtu.be/WMUAc7bvB7M) pour plus d'infos sur ce rôle.
+Vous utiliserez du code pour automatiser les tâches et déployer l’infrastructure. Vous n’avez pas besoin de savoir comment créer des applications complètes, mais comprendre les bases de la programmation vous donnera un avantage. Il existe des rôles des développeurs dédiés dans le cloud. Pour ceux-ci vous aurez besoin de savoir comment construire des solutions complètes, consultez [cette video](https://youtu.be/WMUAc7bvB7M) pour plus d'infos sur ces rôles.
 
-Dans l’étape précédente, vous avez été présenté et avez écrit des scripts Bash. Le script bash est utilisé pour automatiser les tâches et est considéré comme un langage universel pour les serveurs, car de nos jours, Bash est installé par défaut presque sur tous les serveurs Linux.
+Dans l’étape précédente, vous avez été présentés et avez écrit des scripts Bash. Les scripts Bash sont utilisés pour automatiser les tâches et le language est considéré comme un langage universel pour les serveurs, car de nos jours, Bash est installé par défaut sure presque tous les serveurs Linux.
 Je pense qu’il serait maintenant bénéfique d’apprendre plus de compétences en programmation.
 
 
 
-Il existe plusieurs langages de programmation qui sont populaires avec le Cloud,comme Go,Rust,.NET,JavaScript, mais parce que vous êtes débutant,je choisirai [Python](https://www.python.org/). C’est un langage populaire et il existe de nombreuses ressources gratuites de qualité pour l’apprendre et c’est l’un des langages les plus simples pour debuter avec.
+Il existe plusieurs langages de programmation qui sont populaires avec le Cloud, comme Go, Rust, .NET, JavaScript, mais parce que vous êtes débutant,je choisirai [Python](https://www.python.org/). C’est un langage populaire et il existe de nombreuses ressources gratuites de qualité pour l’apprendre et c’est l’un des langages les plus simples pour debuter.
 
 [Git](https://git-scm.com/) est l’outil de contrôle de version le plus populaire et l’une des pratiques DevOps. Il est utilisé pour gérer et partager votre code. GitHub est l’un des services d’hébergement de référentiel Git les plus populaires. Prenez le temps maintenant de créer un compte [GitHub](https://github.com/) si vous n’en avez pas déjà un. Ce sera votre portefeuille de code et vous devriez y mettre autant de projets que vous le souhaitez. 
 
@@ -33,12 +33,12 @@ Bien sûr, n’hésitez pas à passer autant de temps que vous le souhaitez, les
 | Ordre | Titre                                                                     | Notes                                                                                       |
 | :---- | :--------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Optionel     | [Une introduction à la programmation](https://docs.microsoft.com/learn/modules/web-development-101-introduction-programming/)                      | Un excellent module Microsoft Learn sur le sujet.    |
-| 1     | [Python Cours intensif](https://ehmatthes.github.io/pcc/)                      |  Un excellent livre Python,il y a aussi une annexe là-dedans sur Git qui est génial!   
-| 1     | [FreeCodeCamp apprendre python](https://www.youtube.com/watch?v=rfscVS0vtbw)     | L’une des nombreuses ressources precieuses fournies par [FreeCodeCamp](https://www.freecodecamp.org/) |
+| 1     | [Python Cours intensif (Anglais)](https://ehmatthes.github.io/pcc/)                      |  Un excellent livre Python,il y a aussi une annexe là-dedans sur Git qui est génial!   
+| 1     | [FreeCodeCamp apprendre python (Anglais)](https://www.youtube.com/watch?v=rfscVS0vtbw)     | L’une des nombreuses ressources precieuses fournies par [FreeCodeCamp (Anglais)](https://www.freecodecamp.org/) |
 1 | [Prenez vos premiers pas avec python](https://docs.microsoft.com/learn/paths/python-first-steps/) | Un parcours d’apprentissage de 4 heures vous présentant Python |
 1 | [Creez des applications du monde reel avec python](https://docs.microsoft.com/learn/paths/python-language/) | Une ressource d’apprentissage pratique Microsoft de 2 heures
-| 2     | [Introduction à Git ](https://docs.microsoft.com/learn/modules/intro-to-git/)    | Une excellente ressource pour apprendre Git par Microsoft learn                                                               |
-| 2     | [Cours Git FreeCodeCamp](https://youtu.be/RGOj5yH7evk)                           | Une excellente ressource pour apprendre Git par FreeCodeCamp                                                 |
+| 2     | [Introduction à Git](https://docs.microsoft.com/learn/modules/intro-to-git/)    | Une excellente ressource pour apprendre Git par Microsoft learn                                                               |
+| 2     | [Cours Git FreeCodeCamp (Anglais)](https://youtu.be/RGOj5yH7evk)                           | Une excellente ressource pour apprendre Git par FreeCodeCamp                                                 |
 
 
 ## Projets
@@ -46,11 +46,11 @@ Bien sûr, n’hésitez pas à passer autant de temps que vous le souhaitez, les
 
  | Titre                    | Description                                                                                                                                               |
  | :------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
- | [25 projets python pour debutant](https://www.freecodecamp.org/news/python-projects-for-beginners/)| Faites-en autant que vous le souhaitez. |
+ | [25 projets python pour debutant  (Anglais)](https://www.freecodecamp.org/news/python-projects-for-beginners/)| Faites-en autant que vous le souhaitez. |
  [Creer votre profile GitHub readme](https://docs.github.com/en/github/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme) | Créez un fichier README pour parler de vous aux autres. Voici [le mien](https://github.com/madebygps/madebygps) comme un exemple. Rishab en a [un](https://github.com/rishabkumar7/rishabkumar7) aussi.
- | [Mise en réseau de projets Python](https://youtu.be/FGdiSJakIS4)| Développez des compétences en Python et en Réseau.
+ | [Projets de sise en réseau en Python (Anglais)](https://youtu.be/FGdiSJakIS4)| Développez des compétences en Python et en Réseau.
  
-## Les choses que vous devez être familier avec à la fin de cette phase
+## Les choses avec lesquels vous devez être familier à la fin de cette phase
 
 ### Programmation
 
@@ -68,17 +68,17 @@ Bien sûr, n’hésitez pas à passer autant de temps que vous le souhaitez, les
 ### Git
 
 - Comment créer un dépôt localement
-- Comment créer un dépôt Git et le cloner (telecharger) localement
+- Comment créer un dépôt Git et le cloner (télécharger) localement
 - Comment créer une branche Git
 - Comment ajouter des modifications à une branche avec Git
 - Comment fusionner les changements avec Git
 - Comment documenter le code avec un README
 
-## Certifications que vous pourriez vouloir voir
+## Certifications qui pourraient vous intéresser
 
-- [Python Institute certifications](https://pythoninstitute.org/certification/)
+- [Python Institute certifications ](https://pythoninstitute.org/certification-tracks)
 
-Les certifications de programmation ne sont pas en demandes / populaires que celles du cloud. Comme pour toute certification,vous pouvez l’utiliser pour renforcer vos connaissances, mais ce n’est pas une obligation. Il y a beaucoup d’ingénieurs cloud sans certification.
+Les certifications de programmation ne sont pas aussi en demande / populaires que celles du cloud. Comme pour toute certification, vous pouvez l’utiliser pour renforcer vos connaissances, mais ce n’est pas une obligation. Il y a beaucoup d’ingénieurs cloud sans certification.
 
 ## Quelle est la prochaine étape ?
 

--- a/phase2/README.md
+++ b/phase2/README.md
@@ -74,7 +74,7 @@ Of course feel free to spend as much time as you'd like, people have asked for a
 
 ## Certifications you might want to look into
 
-- [Python Institute certifications](https://pythoninstitute.org/certification/)
+- [Python Institute certifications](https://pythoninstitute.org/certification-tracks)
 
 Programming certifications aren't as in demand/popular than cloud ones. As with any certification, you can use it to reinforce your knowledge, but it isn't an obligation. There are plenty of cloud engineers with zero certifications.
 


### PR DESCRIPTION
It looks like the python certification link is no longer valid, the new link is: https://pythoninstitute.org/certification-tracks