### PR TITLE
Phase 2 Broken Python Certification Link Fix

### DIFF
--- a/fr/phase2/README.md
+++ b/fr/phase2/README.md
@@ -76,7 +76,7 @@ Bien sûr, n’hésitez pas à passer autant de temps que vous le souhaitez, les
 
 ## Certifications que vous pourriez vouloir voir
 
-- [Python Institute certifications](https://pythoninstitute.org/certification/)
+- [Python Institute certifications](https://pythoninstitute.org/certification-tracks)
 
 Les certifications de programmation ne sont pas en demandes / populaires que celles du cloud. Comme pour toute certification,vous pouvez l’utiliser pour renforcer vos connaissances, mais ce n’est pas une obligation. Il y a beaucoup d’ingénieurs cloud sans certification.
 

--- a/phase2/README.md
+++ b/phase2/README.md
@@ -74,7 +74,7 @@ Of course feel free to spend as much time as you'd like, people have asked for a
 
 ## Certifications you might want to look into
 
-- [Python Institute certifications](https://pythoninstitute.org/certification/)
+- [Python Institute certifications](https://pythoninstitute.org/certification-tracks)
 
 Programming certifications aren't as in demand/popular than cloud ones. As with any certification, you can use it to reinforce your knowledge, but it isn't an obligation. There are plenty of cloud engineers with zero certifications.
 


### PR DESCRIPTION
It looks like the link for python certifications is no longer valid, the new link is: https://pythoninstitute.org/certification-tracks