### PR TITLE
Updated discord link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,7 +73,7 @@ const config = {
               position: 'left',
             },
             {
-              href: 'http://discord.learntocloud.guide',
+              href: 'https://discord.gg/nxcGpYQpw4',
               label: 'Discord',
               position: 'right',
             },


### PR DESCRIPTION
Discord link doesn't work, generated a new one and added. Once we figure out what's going on with redirect we can replace. 