### PR TITLE
Fix broken link in readme.md

### DIFF
--- a/docs/resources/readme.md
+++ b/docs/resources/readme.md
@@ -6,7 +6,7 @@
  | [Deep work](https://www.calnewport.com/books/deep-work/)             | Another great book, this time about how to focus and get deep work time into your day. |
  | [How I study for certs](https://youtu.be/fpPCZqfOBJs)               | A video with some tips I've picked up on the way                                                                  |
  [Pomodoro technique](https://en.wikipedia.org/wiki/Pomodoro_Technique) | A great method to break up your study time.
-| [How I study for certifications](https://acloudguru.com/blog/engineering/from-student-to-engineer-how-to-study-smarter-for-cloud-cert) | Some tips on studying for Cloud Certifications
+| [How I study for certifications](https://www.pluralsight.com/resources/blog/cloud/from-student-to-engineer-how-to-study-smarter-for-cloud-certs) | Some tips on studying for Cloud Certifications
 
 
  


### PR DESCRIPTION
**I noticed that a link in the README file was pointing to an incorrect URL. This pull request updates the link with the correct address.**

**The blog link in resources section for "How I study for certifications." has been changed by the owner of the blog.**

_Link present as of now is:_ 
https://acloudguru.com/blog/engineering/from-student-to-engineer-how-to-study-smarter-for-cloud-cert

_It is now shifted to:_ 
https://www.pluralsight.com/resources/blog/cloud/from-student-to-engineer-how-to-study-smarter-for-cloud-certs

_Checked via web archive here for content of blog on old link:_
https://web.archive.org/web/20210901155328/https://acloudguru.com/blog/engineering/from-student-to-engineer-how-to-study-smarter-for-cloud-certs?utm_source=twitter&utm_medium=social&utm_campaign=careerblog