### PR TITLE
Added Docker support for LTC website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+## Base ########################################################################
+# Use a larger node image to do the build for native deps (e.g., gcc, python)
+FROM node:lts as base
+
+# Reduce npm log spam and colour during install within Docker
+ENV NPM_CONFIG_LOGLEVEL=warn
+ENV NPM_CONFIG_COLOR=false
+
+# We'll run the app as the `node` user, so put it in their home directory
+WORKDIR /home/node/app
+# Copy the source code over
+COPY --chown=node:node . /home/node/app/
+
+## Development #################################################################
+# Define a development target that installs devDeps and runs in dev mode
+FROM base as development
+WORKDIR /home/node/app
+# Install (not ci) with dependencies, and for Linux vs. Linux Musl (which we use for -alpine)
+RUN npm install
+# Switch to the node user vs. root
+USER node
+# Expose port 3000
+EXPOSE 3000
+# Start the app in debug mode so we can attach the debugger
+CMD ["npm", "start"]
+
+## Production ##################################################################
+# Also define a production target which doesn't use devDeps
+FROM base as production
+WORKDIR /home/node/app
+COPY --chown=node:node --from=development /home/node/app/node_modules /home/node/app/node_modules
+# Build the Docusaurus app
+RUN npm run build
+
+## Deploy ######################################################################
+# Use a stable nginx image
+FROM nginx:stable-alpine as deploy
+WORKDIR /home/node/app
+# Copy what we've installed/built from production
+COPY --chown=node:node --from=production /home/node/app/build /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,42 @@
-## Base ########################################################################
-# Use a larger node image to do the build for native deps (e.g., gcc, python)
+# Stage 1: Base image.
 FROM node:lts as base
+## Disable colour output from yarn to make logs easier to read.
+ENV FORCE_COLOR=0
+## Enable corepack.
+RUN corepack enable
+## Set the working directory to `/opt/docusaurus`.
+WORKDIR /opt/docusaurus
 
-# Reduce npm log spam and colour during install within Docker
-ENV NPM_CONFIG_LOGLEVEL=warn
-ENV NPM_CONFIG_COLOR=false
-
-# We'll run the app as the `node` user, so put it in their home directory
-WORKDIR /home/node/app
-# Copy the source code over
-COPY --chown=node:node . /home/node/app/
-
-## Development #################################################################
-# Define a development target that installs devDeps and runs in dev mode
-FROM base as development
-WORKDIR /home/node/app
-# Install (not ci) with dependencies, and for Linux vs. Linux Musl (which we use for -alpine)
-RUN npm install
-# Switch to the node user vs. root
-USER node
-# Expose port 3000
+# Stage 2a: Development mode.
+FROM base as dev
+## Set the working directory to `/opt/docusaurus`.
+WORKDIR /opt/docusaurus
+## Expose the port that Docusaurus will run on.
 EXPOSE 3000
-# Start the app in debug mode so we can attach the debugger
-CMD ["npm", "start"]
+## Run the development server.
+CMD [ -d "node_modules" ] && npm run start --host 0.0.0.0 --poll 1000 || npm run install && npm run start --host 0.0.0.0 --poll 1000
 
-## Production ##################################################################
-# Also define a production target which doesn't use devDeps
-FROM base as production
-WORKDIR /home/node/app
-COPY --chown=node:node --from=development /home/node/app/node_modules /home/node/app/node_modules
-# Build the Docusaurus app
+# Stage 2b: Production build mode.
+FROM base as prod
+## Set the working directory to `/opt/docusaurus`.
+WORKDIR /opt/docusaurus
+## Copy over the source code.
+COPY . /opt/docusaurus/
+## Install dependencies with `--immutable` to ensure reproducibility.
+RUN npm ci
+## Build the static site.
 RUN npm run build
 
-## Deploy ######################################################################
-# Use a stable nginx image
-FROM nginx:stable-alpine as deploy
-WORKDIR /home/node/app
-# Copy what we've installed/built from production
-COPY --chown=node:node --from=production /home/node/app/build /usr/share/nginx/html/
+# Stage 3a: Serve with `docusaurus serve`.
+FROM prod as serve
+## Expose the port that Docusaurus will run on.
+EXPOSE 3000
+## Run the production server.
+CMD ["npm", "run", "serve", "--", "--host", "0.0.0.0", "--no-open"]
+
+# Stage 3b: Serve with Caddy.
+FROM caddy:2-alpine as caddy
+## Copy the Caddyfile.
+COPY --from=prod /opt/docusaurus/Caddyfile /etc/caddy/Caddyfile
+## Copy the Docusaurus build output.
+COPY --from=prod /opt/docusaurus/build /var/docusaurus

--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ We would love to be your first PR! or any PR for that matter. Take a look at our
 
 If you have ideas for updating the guide content, please open a PR and we would take a look at it.
 
+## Docker Support
+
+You can pull the public image from docker hub [rishabkumar7/ltc-website](https://hub.docker.com/r/rishabkumar7/ltc-website) or build it locally.
+
+### Building the Docker Image:
+
+To build the docker image you will need to run the following command:
+
+``` bash
+docker build --target <target> -t <tag> .
+```
+
+- `--target <target>` - This is the target to build. The target is the name of the stage in the dockerfile. Valid targets are `dev`, `serve` and `caddy`
+- `-t <tag>` - This is the name and tag of the image that will be built. The format is <name>:<tag>. The name can be anything you want. The tag is optional. If you do not specify a tag, latest will be used.
+
+- `.` - This is the path to the build context. In this case we are using the current directory (root directory of this project) as the build context.
+
+### Running the Docker Image
+
+To run the serve target you will need to run the following command:
+
+``` bash
+docker run --rm -d -p 3000:3000 <tag>
+```
+
+- `--rm` - This is an optional flag that will remove the container when it exits.
+- `-d` - This is an optional flag that will run the container in detached mode.
+- `-p 3000:3000` - This is an optional flag that will map port 3000 on the host to port 3000 in the container.
+- `<tag>` - This is the name and tag of the image that will be run. Make sure to use the same tag that you used when building the image.
+
 ## License
 
 Distributed under the MIT License. See [LICENSE](/LICENSE) for more information.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --host 0.0.0.0",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Added Docker support for LTC website.
Docker image is available here - [rishabkumar7/ltc-website](https://hub.docker.com/r/rishabkumar7/ltc-website)

<img width="1874" alt="2024-05-28 11_42_04-" src="https://github.com/learntocloud/learn-to-cloud/assets/45825464/06334b6a-339f-44d0-b09a-e5eec0ab07b6">
