### PR TITLE
Adding DevSecOps Pipeline Tutorials for AWS and GCP

### DIFF
--- a/docs/phase5/csf-projects.md
+++ b/docs/phase5/csf-projects.md
@@ -22,7 +22,7 @@ These projects include detailed instructions for junior engineers:
 | Secure S3 Bucket Configuration | Learn to properly secure S3 buckets and prevent common misconfigurations | [AWS S3 Security Workshop](https://catalog.workshops.aws/s3security/en-US) |
 | Create a Security Monitoring Dashboard | Set up CloudWatch dashboards to monitor security events | [CloudWatch Dashboard Tutorial](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html) |
 | AWS Organization Security | Configure multi-account security controls | [AWS Organization Security](https://docs.aws.amazon.com/prescriptive-guidance/latest/aws-multiaccount-security-strategy/welcome.html) |
-| AWS DevSecOps Pipeline | Build a real-world DevSecOps pipeline in AWS using Terraform, EKS, and CodePipeline to gain hands-on experience with secure CI/CD, container orchestration, and security automation. | [DevSecOps Pipeline - AWS Tutorial](https://www.devsecblueprint.com/projects/devsecops-pipeline-aws/) |
+| AWS DevSecOps Pipeline | Build a real-world DevSecOps pipeline in AWS using Terraform, EKS, and CodePipeline to gain hands-on experience with secure CI/CD, container orchestration, and security automation. | [AWS DevSecOps Pipeline Tutorial](https://www.devsecblueprint.com/projects/devsecops-pipeline-aws/) |
 
 ### AWS
 

--- a/docs/phase5/csf-projects.md
+++ b/docs/phase5/csf-projects.md
@@ -22,6 +22,7 @@ These projects include detailed instructions for junior engineers:
 | Secure S3 Bucket Configuration | Learn to properly secure S3 buckets and prevent common misconfigurations | [AWS S3 Security Workshop](https://catalog.workshops.aws/s3security/en-US) |
 | Create a Security Monitoring Dashboard | Set up CloudWatch dashboards to monitor security events | [CloudWatch Dashboard Tutorial](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html) |
 | AWS Organization Security | Configure multi-account security controls | [AWS Organization Security](https://docs.aws.amazon.com/prescriptive-guidance/latest/aws-multiaccount-security-strategy/welcome.html) |
+| AWS DevSecOps Pipeline | Build a real-world DevSecOps pipeline in AWS using Terraform, EKS, and CodePipeline to gain hands-on experience with secure CI/CD, container orchestration, and security automation. | [DevSecOps Pipeline - AWS Tutorial](https://www.devsecblueprint.com/projects/devsecops-pipeline-aws/) |
 
 ### AWS
 
@@ -52,6 +53,7 @@ These projects include detailed instructions for junior engineers:
 | GCP Security Command Center | Set up and configure Security Command Center | [Security Command Center Quickstart](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center) |
 | Cloud Armor Implementation | Configure WAF rules and DDoS protection | [Cloud Armor Tutorial](https://cloud.google.com/armor/docs/configure-security-policies) |
 | Binary Authorization for GKE | Ensure only trusted containers are deployed | [Binary Authorization Tutorial](https://cloud.google.com/binary-authorization/docs/quickstart) |
+| GCP DevSecOps Pipeline | Build a real-world DevSecOps pipeline in GCP using Terraform, Cloud Build, and Cloud Run to gain hands-on experience with secure CI/CD, infrastructure automation, and container deployment. | [GCP DevSecOps Pipeline Tutorial](https://www.devsecblueprint.com/projects/devsecops-pipeline-gcp/) |
 
 ### GCP
 


### PR DESCRIPTION
This PR contains two minor changes to add links to the AWS and GCP DevSecOps Pipeline Tutorials that are hosted on the DevSec Blueprint's website. Please let me know if you have any questions, comments, or concerns.

Closes: #242 